### PR TITLE
The interval should be the monitor's interval

### DIFF
--- a/alerts/average.js
+++ b/alerts/average.js
@@ -15,9 +15,8 @@ module.exports = function(type, property, opts) {
   // are the options the alerter was created with, and the options we were added
   // with, respectively.
   function init(monitor, context, emit, myOpts, opts, callback) {
-    if (monitor.pollInterval >= period) {
-      return callback('Threshold period must be greater than the monitor polling interval');
-    }
+    interval = monitor.pollInterval;
+
     // Because we may be listening to updates from many peers, we'll keep unique
     // statistics for each of them.
     context.peerStates = {};
@@ -26,7 +25,6 @@ module.exports = function(type, property, opts) {
     // have had a chance to report their stats.
     context.epoch = 0;
 
-    interval = opts.pollInterval;
     return callback();
   }
 

--- a/alerts/threshold.js
+++ b/alerts/threshold.js
@@ -42,6 +42,8 @@ module.exports = function(type, property, opts) {
     if (monitor.pollInterval >= period) {
       return callback('Threshold period must be greater than the monitor polling interval');
     }
+    interval = monitor.pollInterval;
+
     context.peerStates = {};
     context.firstUpdate = true;
 
@@ -51,7 +53,6 @@ module.exports = function(type, property, opts) {
       emit(makeWarning(anyLow));
     }, period);
 
-    interval = opts.pollInterval;
     return callback;
   }
 


### PR DESCRIPTION
I originally meant for this to be the case, but didn't have a way to get the polling interval out of the monitor. Essentially, the only use of `interval` is to determine whether a peer's information is still recent ([here](https://github.com/rtc-io/rtc-health/blob/master/alerts/threshold.js#L97-L100)), and this should be based on how often the health monitor is polling for it.

Also `alerts/average` doesn't have a period, so that error was removed.