### PR TITLE
Track connection failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,8 +91,7 @@ module.exports = function(qc, opts) {
     connections[data.id] = tc;
     notify('started', { source: qc.id, about: data.id, tracker: tc });
     log(peerId, pc, data);
-    var gatherEvent = 'pc.' + peerId + '.ice.gathercomplete';
-    qc.on(gatherEvent, function() {
+    qc.on('pc.' + peerId + '.ice.gathercomplete', function() {
       failureTracker(peerId).gatherIsComplete();
     });
     return tc;

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function(qc, opts) {
   var connections = {};
   var timers = {};
   var logs = {};
-  var failureTracker = trackFailures(function(peerId) {
+  var failureTracker = trackFailures(function onConnectionFailure(peerId) {
     emitter.emit('health:connection:failure', {peer: peerId});
   });
 

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports = function(qc, opts) {
         status = newStatus;
 
         if (status === 'connected') {
-          failureTracker(peer.id).reset();
+          failureTracker(peerId).reset();
         }
       }
     });

--- a/lib/failureTracking.js
+++ b/lib/failureTracking.js
@@ -15,7 +15,7 @@ module.exports = function(warn) {
 };
 
 function ConnectionFailureMonitor(peerId, warn) {
-  if (!this instanceof ConnectionFailureMonitor) {
+  if (!(this instanceof ConnectionFailureMonitor)) {
     return new ConnectionFailureMonitor(peerId, warn);
   }
 

--- a/lib/failureTracking.js
+++ b/lib/failureTracking.js
@@ -1,32 +1,60 @@
-var doomCountdowns = {};
-var haveEndedCandidates = {};
-var haveCompletedGather = {};
+var CONNECTION_TIMEOUT_SECONDS = 10;
 
-function checkDoomCountdown(peerId) {
-  if (doomCountdowns[peerId]) {
+// Close over the warning function so we can pass it to all created monitors.
+module.exports = function(warn) {
+  var monitors = {};
+
+  // Create or lookup a monitor for a particular peer.
+  return function(peerId) {
+    if (monitors[peerId]) {
+      return monitors[peerId];
+    } else {
+      return (monitors[peerId] = new ConnectionFailureMonitor(peerId, warn));
+    }
+  };
+};
+
+function ConnectionFailureMonitor(peerId, warn) {
+  if (!this instanceof ConnectionFailureMonitor) {
+    return new ConnectionFailureMonitor(peerId, warn);
+  }
+
+  this.peerId = peerId;
+  this.warn = warn;
+  this.gathered = false;
+  this.ended = false;
+  this.timeout = undefined;
+}
+
+ConnectionFailureMonitor.prototype.gatherIsComplete = function() {
+  this.gathered = true;
+  this.check();
+};
+
+ConnectionFailureMonitor.prototype.candidatesHaveEnded = function() {
+  this.ended = true;
+  this.check();
+};
+
+ConnectionFailureMonitor.prototype.check = function() {
+  if (this.timeout) {
     return;
   }
 
-  if (haveEndedCandidates[peerId] && haveCompletedGather[peerId]) {
-    doomCountdowns[peerId] = setTimeout(function() {
-      console.log('AAAAAAAAARRRRRGHHH failed to connect to peer %s', peerId);
-      endDoomCountdown(peerId);
-    }, 10 * 1000);
+  if (this.gathered && this.ended) {
+    var self = this;
+    this.timeout = setTimeout(function() {
+      self.warn(self.peerId);
+      self.reset();
+    }, CONNECTION_TIMEOUT_SECONDS * 1000);
   }
-}
+};
 
-function endDoomCountdown(peerId) {
-  var doom = doomCountdowns[peerId];
-  if (doom) {
-    clearTimeout(doom);
+ConnectionFailureMonitor.prototype.reset = function() {
+  this.gathered = false;
+  this.ended = false;
+  if (this.timeout) {
+    clearTimeout(this.timeout);
+    this.timeout = undefined;
   }
-  delete doomCountdowns[peerId];
-  delete haveEndedCandidates[peerId];
-  delete haveCompletedGather[peerId];
-}
-
-module.exports = {
-  checkDoomCountdown: checkDoomCountdown,
-  haveEndedCandidates: haveEndedCandidates,
-  haveCompletedGather: haveCompletedGather,
 };

--- a/lib/failureTracking.js
+++ b/lib/failureTracking.js
@@ -1,0 +1,32 @@
+var doomCountdowns = {};
+var haveEndedCandidates = {};
+var haveCompletedGather = {};
+
+function checkDoomCountdown(peerId) {
+  if (doomCountdowns[peerId]) {
+    return;
+  }
+
+  if (haveEndedCandidates[peerId] && haveCompletedGather[peerId]) {
+    doomCountdowns[peerId] = setTimeout(function() {
+      console.log('AAAAAAAAARRRRRGHHH failed to connect to peer %s', peerId);
+      endDoomCountdown(peerId);
+    }, 10 * 1000);
+  }
+}
+
+function endDoomCountdown(peerId) {
+  var doom = doomCountdowns[peerId];
+  if (doom) {
+    clearTimeout(doom);
+  }
+  delete doomCountdowns[peerId];
+  delete haveEndedCandidates[peerId];
+  delete haveCompletedGather[peerId];
+}
+
+module.exports = {
+  checkDoomCountdown: checkDoomCountdown,
+  haveEndedCandidates: haveEndedCandidates,
+  haveCompletedGather: haveCompletedGather,
+};


### PR DESCRIPTION
This causes the health monitor to emit an event `health:connection:failure` with a data object `{peer: 'peer_id'}` when a peer connection fails to enter the `connected` state within 10 seconds of both the `gathercomplete` and `endofcandidates` events occurring.