### PR TITLE
Add failure detection code to MonitoredConnection class

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,8 +82,12 @@ module.exports = function(qc, opts) {
     emitter.emit.apply(emitter, (['health:' + eventName, opts].concat(args)));
   }
 
+  function connectionFailure(tc) {
+    emitter.emit('health:connection:failure', tc);
+  }
+
   function trackConnection(peerId, pc, data) {
-    var tc = new MonitoredConnection(qc.id, pc, data);
+    var tc = new MonitoredConnection(qc, pc, data, {onFailure: connectionFailure});
     connections[data.id] = tc;
     notify('started', { source: qc.id, about: data.id, tracker: tc });
     log(peerId, pc, data);
@@ -113,6 +117,9 @@ module.exports = function(qc, opts) {
       if (status != newStatus) {
         emitter.emit('health:connection:status', tc, newStatus, status);
         status = newStatus;
+        if (status === 'connected') {
+          tc._resetFailureConditions();
+        }
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ module.exports = function(qc, opts) {
         emitter.emit('health:connection:status', tc, newStatus, status);
         status = newStatus;
         if (status === 'connected') {
-          tc._resetFailureConditions();
+          tc.connected();
         }
       }
     });

--- a/index.js
+++ b/index.js
@@ -87,7 +87,10 @@ module.exports = function(qc, opts) {
   }
 
   function trackConnection(peerId, pc, data) {
-    var tc = new MonitoredConnection(qc, pc, data, {onFailure: connectionFailure});
+    var tc = new MonitoredConnection(qc, pc, data, {
+      timeUntilFailure: opts.connectionFailureTime,
+      onFailure: connectionFailure,
+    });
     connections[data.id] = tc;
     notify('started', { source: qc.id, about: data.id, tracker: tc });
     log(peerId, pc, data);

--- a/index.js
+++ b/index.js
@@ -122,6 +122,8 @@ module.exports = function(qc, opts) {
         status = newStatus;
         if (status === 'connected') {
           tc.connected();
+        } else if (status === 'error') {
+          tc.failed();
         }
       }
     });

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -47,6 +47,8 @@ MonitoredConnection.prototype.close = function() {
 	}
 }
 
+// This should be called once the connection's status is "connected". It only
+// exists so that we don't have to call private functions from outside the class!
 MonitoredConnection.prototype.connected = function() {
 	this._resetFailureConditions();
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -15,6 +15,7 @@ function MonitoredConnection(qc, pc, data, opts) {
 	this._candidatesEnded = false;
 	this._failureTimeout = null;
 	this._failureCallback = opts.onFailure;
+	this._timeUntilFailure = opts.timeUntilFailure;
 
 	// These two events are the preconditions for starting the connection failure
 	// countdown.
@@ -56,8 +57,6 @@ MonitoredConnection.prototype.connected = function() {
 /**
   Internal methods for detecting connection failure
  **/
-var CONNECTION_TIMEOUT_SECONDS = 10;
-
 MonitoredConnection.prototype._gatherIsComplete = function() {
 	this._candidatesGathered = true;
 	this._checkFailureConditions();
@@ -68,19 +67,25 @@ MonitoredConnection.prototype._candidatesHaveEnded = function() {
 	this._checkFailureConditions();
 };
 
+var CONNECTION_TIMEOUT_MSEC = 10 * 1000;
+
 MonitoredConnection.prototype._checkFailureConditions = function() {
 	if (this._failureTimeout) {
 		return;
 	}
 
 	if (this._candidatesGathered && this._candidatesEnded) {
+		var time = this._timeUntilFailure;
+		if (time === undefined) {
+			time = CONNECTION_TIMEOUT_MSEC;
+		}
 		var self = this;
 		this._failureTimeout = setTimeout(function() {
 			if (self._failureCallback) {
 				self._failureCallback(self);
 			}
 			self._resetFailureConditions();
-		}, CONNECTION_TIMEOUT_SECONDS * 1000);
+		}, time);
 	}
 };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,16 +1,33 @@
 var util = require('./util');
 
-function MonitoredConnection(id, pc, opts) {
-	this.source = id;
-	this.target = opts.id;
-	this.room = opts.room;
+function MonitoredConnection(qc, pc, data, opts) {
+	opts = opts || {};
+
+	this.source = qc.id;
+	this.target = data.id;
+	this.room = data.room;
 	this.pc = pc;
 
 	this._active = 0;
 	this.started = Date.now();
 
+	this._candidatesGathered = false;
+	this._candidatesEnded = false;
+	this._failureTimeout = null;
+	this._failureCallback = opts.onFailure;
+
+	// These two events are the preconditions for starting the connection failure
+	// countdown.
+	var self = this;
+	qc.on('pc.' + this.target + '.ice.gathercomplete', function() {
+		self._gatherIsComplete();
+	});
+	qc.on('message:endofcandidates', function() {
+		self._candidatesHaveEnded();
+	});
+
 	// Create a unique connection id
-    this.connection_id = util.connectionId(this.source, this.target);
+	this.connection_id = util.connectionId(this.source, this.target);
 }
 
 /**
@@ -22,7 +39,50 @@ MonitoredConnection.prototype.closed = function() {
 }
 
 MonitoredConnection.prototype.close = function() {
-	if (this.pc && this.pc.iceConnectionState != 'closed') this.pc.close();
+	if (this.pc && this.pc.iceConnectionState != 'closed') {
+		this.pc.close();
+		this._resetFailureConditions();
+	}
 }
+
+/**
+  Internal methods for detecting connection failure
+ **/
+var CONNECTION_TIMEOUT_SECONDS = 10;
+
+MonitoredConnection.prototype._gatherIsComplete = function() {
+	this._candidatesGathered = true;
+	this._checkFailureConditions();
+};
+
+MonitoredConnection.prototype._candidatesHaveEnded = function() {
+	this._candidatesEnded = true;
+	this._checkFailureConditions();
+};
+
+MonitoredConnection.prototype._checkFailureConditions = function() {
+	if (this._failureTimeout) {
+		return;
+	}
+
+	if (this._candidatesGathered && this._candidatesEnded) {
+		var self = this;
+		this._failureTimeout = setTimeout(function() {
+			if (self._failureCallback) {
+				self._failureCallback(self);
+			}
+			self._resetFailureConditions();
+		}, CONNECTION_TIMEOUT_SECONDS * 1000);
+	}
+};
+
+MonitoredConnection.prototype._resetFailureConditions = function() {
+	this._candidatesGathered = false;
+	this._candidatesEnded = false;
+	if (this._failureTimeout) {
+		clearTimeout(this._failureTimeout);
+		this._failureTimeout = null;
+	}
+};
 
 exports.MonitoredConnection = MonitoredConnection;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -45,6 +45,10 @@ MonitoredConnection.prototype.close = function() {
 	}
 }
 
+MonitoredConnection.prototype.connected = function() {
+	this._resetFailureConditions();
+};
+
 /**
   Internal methods for detecting connection failure
  **/

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -22,8 +22,10 @@ function MonitoredConnection(qc, pc, data, opts) {
 	qc.on('pc.' + this.target + '.ice.gathercomplete', function() {
 		self._gatherIsComplete();
 	});
-	qc.on('message:endofcandidates', function() {
-		self._candidatesHaveEnded();
+	qc.on('message:endofcandidates', function(msg, peer, raw) {
+		if (peer.id === self.target) {
+			self._candidatesHaveEnded();
+		}
 	});
 
 	// Create a unique connection id

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -48,14 +48,20 @@ MonitoredConnection.prototype.close = function() {
 	}
 }
 
-// This should be called once the connection's status is "connected". It only
-// exists so that we don't have to call private functions from outside the class!
+/**
+  Methods for notifying the MC of its connectivity state based on outside event
+  knowledge.
+ **/
 MonitoredConnection.prototype.connected = function() {
 	this._resetFailureConditions();
 };
 
+MonitoredConnection.prototype.failed = function() {
+	this._onFailure();
+};
+
 /**
-  Internal methods for detecting connection failure
+  Internal methods used in detecting connection failure
  **/
 MonitoredConnection.prototype._gatherIsComplete = function() {
 	this._candidatesGathered = true;
@@ -81,12 +87,16 @@ MonitoredConnection.prototype._checkFailureConditions = function() {
 		}
 		var self = this;
 		this._failureTimeout = setTimeout(function() {
-			if (self._failureCallback) {
-				self._failureCallback(self);
-			}
-			self._resetFailureConditions();
+			self._onFailure();
 		}, time);
 	}
+};
+
+MonitoredConnection.prototype._onFailure = function() {
+	if (this._failureCallback) {
+		this._failureCallback(this);
+	}
+	this._resetFailureConditions();
 };
 
 MonitoredConnection.prototype._resetFailureConditions = function() {

--- a/test/all.js
+++ b/test/all.js
@@ -1,2 +1,3 @@
 require('./health-test')(location.origin);
 require('./alerts-test')(location.origin);
+require('./failure-test')(location.origin);

--- a/test/failure-test.js
+++ b/test/failure-test.js
@@ -1,0 +1,54 @@
+var test = require('tape');
+var async = require('async');
+var peerHelper = require('./helpers/peer');
+var room = 'rtchealth-ut-' + require('uuid').v4();
+var Promise = require('es6-promise').Promise;
+
+// require('cog/logger').enable('*');
+module.exports = function(signallingServer) {
+
+    var newPeer = peerHelper.peerCreator(signallingServer, {
+        room: room,
+        filterCandidate: function() {
+          return false;
+        },
+        monitorOpts: {
+            pollInterval: 10000,
+            connectionFailureTime: 100,
+        },
+    });
+
+    test('rtc-health events', function(t) {
+
+        var createPeer = newPeer.bind(newPeer, t);
+        async.parallel([createPeer, createPeer], function(err, peers) {
+                
+            t.ok(peers.length === 2, 'two peers created');
+
+            var source = peers[0];
+            var target = peers[1];
+
+            var firstSourceFailure = new Promise(function(resolve, reject) {
+                // We fulfil the promise only if the connection failure is noticed.
+                source.monitor.on('health:connection:failure', function(tc) {
+                    resolve(tc);
+                });
+
+                // Timeout to keep the test from stalling.
+                setTimeout(function() {
+                    reject();
+                }, 1000);
+            });
+
+            t.test('track connection failure', function(t) {
+                firstSourceFailure.then(function() {
+                    t.pass('connection failure was caught');
+                    t.end();
+                }, function() {
+                    t.fail('connection failure was not caught');
+                    t.end();
+                });
+            });
+        });
+    });
+};

--- a/test/failure-test.js
+++ b/test/failure-test.js
@@ -9,16 +9,19 @@ module.exports = function(signallingServer) {
 
     var newPeer = peerHelper.peerCreator(signallingServer, {
         room: room,
+        // Block all actual connections from occuring!
         filterCandidate: function() {
           return false;
         },
         monitorOpts: {
             pollInterval: 10000,
+            // The failure time can be arbitrary and small since connections are
+            // blocked. Long timeouts here just make the tests slower.
             connectionFailureTime: 100,
         },
     });
 
-    test('rtc-health events', function(t) {
+    test('failure tracking', function(t) {
 
         var createPeer = newPeer.bind(newPeer, t);
         async.parallel([createPeer, createPeer], function(err, peers) {
@@ -34,7 +37,8 @@ module.exports = function(signallingServer) {
                     resolve(tc);
                 });
 
-                // Timeout to keep the test from stalling.
+                // Timeout to keep the test from stalling for too long in
+                // unexpected conditions.
                 setTimeout(function() {
                     reject();
                 }, 1000);


### PR DESCRIPTION
Replaces #4, reimplementing the failure tracking logic in `MonitoredConnection` instead of in a utility class. This involves a change to the constructor of `MonitoredEvent`, which now takes the QuickConnect object instead of its ID, and a set of options _as well as_ the data from the peer connection.

~~The one part of this I'm not happy with is [this line](https://github.com/rtc-io/rtc-health/compare/rtc-io:master...eightyeight:track-failure-in-monitoredconnection?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR121), which calls the 'private' `_resetFailureConditions` method on the connection to stop the countdown when the connection succeeds.~~ I just added a public method, `connected()`, which does nothing currently except calling the private method. Acceptable?

Note that each `MonitoredConnection` creates its own event listener `qc.on('message:endofcandidates'`. This is slightly inefficient.