### PR TITLE
Reset failure conditions on close event

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -39,12 +39,12 @@ function MonitoredConnection(qc, pc, data, opts) {
 MonitoredConnection.prototype.closed = function() {
 	this._active += (Date.now() - this.started);
 	this.started = null;
+	this._resetFailureConditions();
 }
 
 MonitoredConnection.prototype.close = function() {
 	if (this.pc && this.pc.iceConnectionState != 'closed') {
 		this.pc.close();
-		this._resetFailureConditions();
 	}
 }
 


### PR DESCRIPTION
Just trigger the failure conditions reset as a response to the 'closed' event to prevent connections that are deliberately terminated (ie. user activity, browser close) before connection do not trigger a 'failed to connect' error.