### PR TITLE
Prevent multiple failure events

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -7,6 +7,7 @@ function MonitoredConnection(qc, pc, data, opts) {
 	this.target = data.id;
 	this.room = data.room;
 	this.pc = pc;
+	this.qc = qc;
 
 	this._active = 0;
 	this.started = Date.now();
@@ -20,14 +21,13 @@ function MonitoredConnection(qc, pc, data, opts) {
 	// These two events are the preconditions for starting the connection failure
 	// countdown.
 	var self = this;
-	qc.on('pc.' + this.target + '.ice.gathercomplete', function() {
-		self._gatherIsComplete();
-	});
-	qc.on('message:endofcandidates', function(msg, peer, raw) {
-		if (peer.id === self.target) {
-			self._candidatesHaveEnded();
-		}
-	});
+	this._handlers = {
+		gathercomplete: this._handleGatherComplete.bind(this),
+		endofcandidates: this._handleCandidatesEnded.bind(this)
+	};
+
+	qc.on('pc.' + this.target + '.ice.gathercomplete', this._handlers.gathercomplete);
+	qc.on('message:endofcandidates', this._handlers.endofcandidates);
 
 	// Create a unique connection id
 	this.connection_id = util.connectionId(this.source, this.target);
@@ -63,14 +63,16 @@ MonitoredConnection.prototype.failed = function() {
 /**
   Internal methods used in detecting connection failure
  **/
-MonitoredConnection.prototype._gatherIsComplete = function() {
+MonitoredConnection.prototype._handleGatherComplete = function() {
 	this._candidatesGathered = true;
 	this._checkFailureConditions();
 };
 
-MonitoredConnection.prototype._candidatesHaveEnded = function() {
-	this._candidatesEnded = true;
-	this._checkFailureConditions();
+MonitoredConnection.prototype._handleCandidatesEnded = function(msg, peer, raw) {
+	if (peer.id === this.target) {
+		this._candidatesEnded = true;
+		this._checkFailureConditions();
+	}
 };
 
 var CONNECTION_TIMEOUT_MSEC = 10 * 1000;
@@ -106,6 +108,9 @@ MonitoredConnection.prototype._resetFailureConditions = function() {
 		clearTimeout(this._failureTimeout);
 		this._failureTimeout = null;
 	}
+
+	this.qc.off('pc.' + this.target + '.ice.gathercomplete', this._handlers.gathercomplete);
+	this.qc.off('message:endofcandidates', this._handlers.endofcandidates);
 };
 
 exports.MonitoredConnection = MonitoredConnection;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "rtc-switchboard-messenger": "^1.2.0",
     "tap-spec": "^4.0.2",
     "tape": "^3.0.3",
-    "travis-multirunner": "^2.7.2"
+    "travis-multirunner": "^3.0.0"
   },
   "author": "Nathan Oehlman",
   "license": "Apache 2.0",


### PR DESCRIPTION
If reconnecting to a peerId that has already previously existed, this will cause events from the previous monitor to fire (plus leak). This should fix that.