### PR TITLE
Prevent connection failures for normal call closure

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,8 +83,9 @@ module.exports = function(qc, opts) {
     emitter.emit.apply(emitter, (['health:' + eventName, opts].concat(args)));
   }
 
-  function connectionFailure(tc) {
-    emitter.emit('health:connection:failure', tc);
+  function connectionFailure() {
+    var args = Array.prototype.slice.call(arguments);
+    emitter.emit.apply(emitter, ['health:connection:failure'].concat(args));
   }
 
   function trackConnection(peerId, pc, data) {
@@ -148,7 +149,7 @@ module.exports = function(qc, opts) {
         if (status === 'connected') {
           tc.connected();
         } else if (status === 'error') {
-          tc.failed();
+          tc.failed('ICE connection state error');
         }
       }
     });

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -89,14 +89,14 @@ MonitoredConnection.prototype._checkFailureConditions = function() {
 		}
 		var self = this;
 		this._failureTimeout = setTimeout(function() {
-			self._onFailure();
+			self.failed('Connection timed out');
 		}, time);
 	}
 };
 
-MonitoredConnection.prototype._onFailure = function() {
+MonitoredConnection.prototype._onFailure = function(err) {
 	if (this._failureCallback) {
-		this._failureCallback(this);
+		this._failureCallback(this, err);
 	}
 	this._resetFailureConditions();
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -56,8 +56,8 @@ MonitoredConnection.prototype.connected = function() {
 	this._resetFailureConditions();
 };
 
-MonitoredConnection.prototype.failed = function() {
-	this._onFailure();
+MonitoredConnection.prototype.failed = function(err) {
+	this._onFailure(err);
 };
 
 /**

--- a/test/all.js
+++ b/test/all.js
@@ -1,3 +1,4 @@
 require('./health-test')(location.origin);
 require('./alerts-test')(location.origin);
 require('./failure-test')(location.origin);
+require('./failure-exception-test')(location.origin);

--- a/test/failure-exception-test.js
+++ b/test/failure-exception-test.js
@@ -1,0 +1,56 @@
+var test = require('tape');
+var async = require('async');
+var peerHelper = require('./helpers/peer');
+var room = 'rtchealth-ut-' + require('uuid').v4();
+
+module.exports = function(signallingServer) {
+
+    var newPeer = peerHelper.peerCreator(signallingServer, {
+        room: room,
+        // Block all actual connections from occuring!
+        filterCandidate: function() {
+          return false;
+        },
+        monitorOpts: {
+            pollInterval: 10000,
+            // The failure time can be arbitrary and small since connections are
+            // blocked. Long timeouts here just make the tests slower.
+            connectionFailureTime: 500,
+        },
+    });
+
+    test('failure does not get reported if call is terminated prior to connection', function(t) {
+        var createPeer = newPeer.bind(newPeer, t);
+        async.parallel([createPeer, createPeer], function(err, peers) {
+            t.ok(peers.length === 2, 'two peers created');
+
+
+            t.test('termination', function(t1) {
+                t1.plan(3);
+                var source = peers[0];
+                var target = peers[1];
+
+                function failOnFailure(tc, err) {
+                    t1.fail('A health connection failure was detected [' + err + ']');
+                }
+
+                source.monitor.on('health:connection:failure', failOnFailure);
+                target.monitor.on('health:connection:failure', failOnFailure);
+
+                source.connection.on('call:ended', t1.pass.bind(t1, 'Source call was ended'));
+                target.connection.on('call:ended', t1.pass.bind(t1, 'Target call was ended'));
+
+                source.connection.on('peer:couple', function() {
+                    source.connection.endCalls();
+                });
+                target.connection.on('peer:couple', function() {
+                    target.connection.endCalls();
+                });
+
+                setTimeout(function() {
+                    t1.pass('No failure event raised');
+                }, 1000);
+            });
+        });
+    });
+};

--- a/test/failure-test.js
+++ b/test/failure-test.js
@@ -25,7 +25,7 @@ module.exports = function(signallingServer) {
 
         var createPeer = newPeer.bind(newPeer, t);
         async.parallel([createPeer, createPeer], function(err, peers) {
-                
+
             t.ok(peers.length === 2, 'two peers created');
 
             var source = peers[0];

--- a/test/helpers/peer.js
+++ b/test/helpers/peer.js
@@ -6,7 +6,6 @@ exports.peerCreator = function(signallingServer, opts) {
 	opts = opts || {};
 	return function(t, callback) {
 	    t.test('create a new peer', function(t) {
-	    	console.log('create peer');
 	        t.plan(3);
 	        var sig = signaller(require('rtc-switchboard-messenger')(signallingServer));
 	        sig.once('connected', function() {

--- a/test/helpers/peer.js
+++ b/test/helpers/peer.js
@@ -6,6 +6,7 @@ exports.peerCreator = function(signallingServer, opts) {
 	opts = opts || {};
 	return function(t, callback) {
 	    t.test('create a new peer', function(t) {
+	    	console.log('create peer');
 	        t.plan(3);
 	        var sig = signaller(require('rtc-switchboard-messenger')(signallingServer));
 	        sig.once('connected', function() {
@@ -15,7 +16,7 @@ exports.peerCreator = function(signallingServer, opts) {
 	        t.ok(connection, 'new quickconnect created');
 	        var monitor = health(connection, opts.monitorOpts || { pollInterval: 10000 });
 	        t.ok(monitor, 'monitor attached');
-	        return callback(null, { connection: connection, monitor: monitor } );  
+	        return callback(null, { connection: connection, monitor: monitor } );
 	    });
 	};
 }


### PR DESCRIPTION
Currently, if a call is manually ended prior to a PeerConnection connected, it will still throw a connection failure error.

This will listen for `call:ended` events and prevent this from happening.