### PR TITLE
`call:failed` triggers a connection failure event

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,11 @@ module.exports = function(qc, opts) {
     monitor.on('closed', connectionClosed.bind(this, peerId));
   });
 
+  qc.on('call:failed', function(peerId) {
+    var tc = connections[peerId];
+    tc.failed('Call failed to connect');
+  });
+
   // Close tracked connections on call:ended as well
   qc.on('call:ended', connectionClosed);
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -11,6 +11,7 @@ function MonitoredConnection(qc, pc, data, opts) {
 
 	this._active = 0;
 	this.started = Date.now();
+	this.connectedAt = null;
 
 	this._candidatesGathered = false;
 	this._candidatesEnded = false;
@@ -53,6 +54,7 @@ MonitoredConnection.prototype.close = function() {
   knowledge.
  **/
 MonitoredConnection.prototype.connected = function() {
+	this.connectedAt = new Date();
 	this._resetFailureConditions();
 };
 

--- a/test/failure-test.js
+++ b/test/failure-test.js
@@ -41,7 +41,7 @@ module.exports = function(signallingServer) {
                 // unexpected conditions.
                 setTimeout(function() {
                     reject();
-                }, 1000);
+                }, 2000);
             });
 
             t.test('track connection failure', function(t) {


### PR DESCRIPTION
If the `call:failed` event fires after call setup, it will result in the tracked connection throwing a failure.

Also, adds a `connectedAt` property which allows us to determine if a TrackedConnection has ever had a successful connection.