### PR TITLE
Improve the reliability of the preconnection exception test

### DIFF
--- a/test/failure-exception-test.js
+++ b/test/failure-exception-test.js
@@ -1,12 +1,14 @@
 var test = require('tape');
 var async = require('async');
 var peerHelper = require('./helpers/peer');
-var room = 'rtchealth-ut-' + require('uuid').v4();
 
 module.exports = function(signallingServer) {
 
+    var room = 'rtchealth-ut-' + require('uuid').v4();
+
     var newPeer = peerHelper.peerCreator(signallingServer, {
         room: room,
+        manualJoin: true,
         // Block all actual connections from occuring!
         filterCandidate: function() {
           return false;
@@ -19,33 +21,55 @@ module.exports = function(signallingServer) {
         },
     });
 
-    test('failure does not get reported if call is terminated prior to connection', function(t) {
+    test('failure does not get reported if call is terminated prior to connection', {timeout: 30000}, function(t) {
         var createPeer = newPeer.bind(newPeer, t);
         async.parallel([createPeer, createPeer], function(err, peers) {
             t.ok(peers.length === 2, 'two peers created');
 
-
             t.test('termination', function(t1) {
-                t1.plan(3);
+                t1.plan(8);
                 var source = peers[0];
                 var target = peers[1];
+                var sourceCreated = false;
+                var targetCreated = false;
 
                 function failOnFailure(tc, err) {
                     t1.fail('A health connection failure was detected [' + err + ']');
                 }
 
+                function terminateOnCreate() {
+                    if (!sourceCreated || !targetCreated) return setTimeout(terminateOnCreate, 0);
+                    source.connection.endCalls();
+                    target.connection.endCalls();
+                }
+
                 source.monitor.on('health:connection:failure', failOnFailure);
                 target.monitor.on('health:connection:failure', failOnFailure);
 
+                source.connection.on('call:started', t1.fail.bind(t1, 'Source call started'));
+                target.connection.on('call:started', t1.fail.bind(t1, 'Target call started'));
+
+                source.connection.on('call:failed', t1.fail.bind(t1, 'Source call failed'));
                 source.connection.on('call:ended', t1.pass.bind(t1, 'Source call was ended'));
                 target.connection.on('call:ended', t1.pass.bind(t1, 'Target call was ended'));
 
-                source.connection.on('peer:couple', function() {
-                    source.connection.endCalls();
+                source.connection.on('call:created', t1.pass.bind(t1, 'Source call created'));
+                target.connection.on('call:created', t1.pass.bind(t1, 'Target call created'));
+
+                source.connection.on('call:created', function() {
+                    t1.pass('source has been created');
+                    sourceCreated = true;
+
                 });
-                target.connection.on('peer:couple', function() {
-                    target.connection.endCalls();
+                target.connection.on('call:created', function() {
+                    t1.pass('target has been created');
+                    targetCreated = true;
                 });
+
+                terminateOnCreate();
+                source.connection.join();
+                target.connection.join();
+                t1.pass('Connection joining');
 
                 setTimeout(function() {
                     t1.pass('No failure event raised');

--- a/test/failure-test.js
+++ b/test/failure-test.js
@@ -1,11 +1,12 @@
 var test = require('tape');
 var async = require('async');
 var peerHelper = require('./helpers/peer');
-var room = 'rtchealth-ut-' + require('uuid').v4();
 var Promise = require('es6-promise').Promise;
 
 // require('cog/logger').enable('*');
 module.exports = function(signallingServer) {
+
+    var room = 'rtchealth-ut-' + require('uuid').v4();
 
     var newPeer = peerHelper.peerCreator(signallingServer, {
         room: room,


### PR DESCRIPTION
As above, fixes the issue with the preconnection exception test whereby the source peer would commence coupling prior to the events in the `termination` test being attached.