### PR TITLE
Add in rudimentary support for standards based API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-- 0.10
+- "6"
+- "lts/*"
 
 env:
   matrix:
@@ -29,4 +30,4 @@ after_failure:
 
 notifications:
   email:
-  - nathan.oehlman@nicta.com.au
+  - nathan+rtcio@coviu.com

--- a/example/capture.js
+++ b/example/capture.js
@@ -18,7 +18,7 @@ localMedia.render(local);
 localMedia.once('capture', function(stream) {
 
 	var qc = window.qc =
-	quickconnect('http://rtc.io/switchboard/', {
+	quickconnect('http://localhost:3000/', {
 		room: 'health-capture',
 		iceServers: [
 		  { url: 'stun:stun.l.google.com:19302' }

--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ module.exports = function(qc, opts) {
 
   // Provider detection
   function detect() {
-    provider = detectProvider();
+    provider = detectProvider(opts);
     if (!provider) {
       console.log('WARNING! No WebRTC provider detected - rtc-health is disabled until a provider is detected');
     }

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -9,14 +9,15 @@ var providers = [
 	require('./providers/unsupported'),
 ];
 
-module.exports = function() {
+module.exports = function(opts) {
 	var detected = null;
+	var requested = opts && opts.provider;
 
 	// Check for the existing of the RTCPeerConnection
 	for (var i = 0; i < providers.length; i++) {
 		var pv = providers[i];
 		var RTCPeerConnection = window[(pv.RTC_PREFIX || '') + 'RTCPeerConnection'];
-		if (RTCPeerConnection || (pv.check && pv.check())) {
+		if ((requested && requested === pv.id) || RTCPeerConnection || (!requested && pv.check && pv.check())) {
 			detected = pv;
 			break;
 		}

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -2,8 +2,9 @@
   Detects and loads the correct provider for this browser
  **/
 var providers = [
+	require('./providers/standard'),
 	require('./providers/google'),
-	require('./providers/mozilla'),
+	require('./providers/mozilla'),	
 	require('./providers/temasys'),
 	require('./providers/unsupported'),
 ];

--- a/lib/providers/google.js
+++ b/lib/providers/google.js
@@ -11,7 +11,7 @@ exports.id = 'chrome';
   Gets the RTCStats for a given RTCPeerConnection
  **/
 exports.getStats = function(pc, opts, callback) {
-    pc.getStats(function(stats) {
+	pc.getStats().then((stats) => {
     	if (!stats) return callback('Could not getStats');
     	var result = stats.result();
     	var reports = [];
@@ -19,7 +19,9 @@ exports.getStats = function(pc, opts, callback) {
     		reports.push(convertToStatsReport(result[i]));
     	}
     	return callback(null, reports);
-    });
+    }).catch((err) => {
+		callback('Could not getStats')
+	});
 }
 
 /**

--- a/lib/providers/standard.js
+++ b/lib/providers/standard.js
@@ -58,5 +58,5 @@ exports.getStats = function(pc, opts, callback) {
   Check if we are using a browser that is supporting the standardized stats reports
  **/
 exports.check = function() {
-    return bowser && bowser.check({ safari: '12', chrome: '69' }, true);
+    return bowser && bowser.check({ safari: '12' }, true);
 };

--- a/lib/providers/standard.js
+++ b/lib/providers/standard.js
@@ -1,0 +1,62 @@
+/**
+ * The standard provider deals with StatsReport that adhere to the common standard
+ */
+var bowser = require('bowser');
+var StatsReport = require('../statsreport');
+var util = require('../util');
+var EXCLUDE_FIELDS = ['id', 'type'];
+// Don't send reports about the certificate or codec information
+var EXCLUDE_TYPES = ['certificate', 'codec'];
+var FIELD_PREFIX = '';
+
+/**
+  Convert the Chrome RTCStatsReport to a StatsReport
+ **/
+function convertToStatsReport(report, compare) {
+	if (!report || !report.type || EXCLUDE_TYPES.indexOf(report.type) !== -1) return;
+
+	var result = new StatsReport({
+        id: report.id,
+        type: util.standardizeKey(FIELD_PREFIX, report.type),
+        subType: (report.type === 'ssrc' ? (report.id.indexOf('send') > 0 ? 'send' : 'receive') : undefined),
+        timestamp: report.timestamp
+    });
+
+    Object.keys(report).filter((k) => EXCLUDE_FIELDS.indexOf(k) === -1).map((key) => {
+        var standardKey = util.standardizeKey(FIELD_PREFIX, key);
+        var value = report[key];        
+        result.set(standardKey, value);
+    });
+	return result;
+}
+
+/**
+  Standardized WebRTC Stats Report
+ **/
+exports.id = 'standard';
+
+/**
+  
+ **/
+exports.getStats = function(pc, opts, callback) {
+    if (!pc || typeof pc.getStats !== 'function') return callback();
+    pc.getStats().then((stats) => {
+    	if (!stats) return callback('Could not getStats');
+        var reports = [];
+        stats.forEach((s) => {
+            var report = convertToStatsReport(s);
+            if (!report) return;
+            reports.push(report);
+        });
+    	return callback(null, reports);
+    }).catch((err) => {
+        callback('Could not getStats');
+    });
+};
+
+/**
+  Check if we are using a browser that is supporting the standardized stats reports
+ **/
+exports.check = function() {
+    return bowser && bowser.check({ safari: '12', chrome: '69' }, true);
+};

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -116,7 +116,7 @@ Reporter.prototype.toJSON = function(opts) {
     if (this.reports) {
         for (var i = 0; i < this.reports.length; i++) {
             var report = this.reports[i];
-            if (exclude && exclude.indexOf(report.type) >= 0) continue;
+            if (!report || !report.type || (exclude && exclude.indexOf(report.type) >= 0)) continue;
 
             // If supplied, find a matching report to compare against
             if (compareTo && compareTo.reports) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "rtc-switchboard-messenger": "^1.2.0",
     "tap-spec": "^4.0.2",
     "tape": "^3.0.3",
-    "travis-multirunner": "^3.0.0"
+    "travis-multirunner": "^4.3.1"
   },
   "author": "Nathan Oehlman",
   "license": "Apache 2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "dependencies": {
     "async": "^0.9.0",
+    "bowser": "^1.9.4",
     "debounce": "^1.0.0",
     "eventemitter3": "^1.1.1",
     "humps": "^0.4.2",


### PR DESCRIPTION
This adds in rudimentary support for the standards based API that is being implemented by browser vendors.

It adds in a new provider `standard` which will be used in Safari 12 and higher. It can also be manually selected by passing `provider: 'standard'` in the options when creating a health monitor instance.