### PR TITLE
Move stats collection from index.js to stat.js for easier use

### DIFF
--- a/lib/providers/standard.js
+++ b/lib/providers/standard.js
@@ -39,17 +39,24 @@ exports.id = 'standard';
   
  **/
 exports.getStats = function(pc, opts, callback) {
-    if (!pc || typeof pc.getStats !== 'function') return callback();
-    pc.getStats().then((stats) => {
-    	if (!stats) return callback('Could not getStats');
-        var reports = [];
-        stats.forEach((s) => {
-            var report = convertToStatsReport(s);
-            if (!report) return;
-            reports.push(report);
-        });
-    	return callback(null, reports);
-    }).catch((err) => {
+    return new Promise((resolve, reject) => {
+        if (!pc || typeof pc.getStats !== 'function') return resolve();
+        // Handle stats requests hanging on Firefox if the connection is closing
+        let timer = setTimeout(() => reject('Timed out'), 1000);
+        pc.getStats().then((stats) => {
+            clearTimeout(timer);
+            if (!stats) return callback('Could not getStats');
+            var reports = [];
+            stats.forEach((s) => {
+                var report = convertToStatsReport(s);
+                if (!report) return;
+                reports.push(report);
+            });            
+            return resolve(reports);
+        })
+    })
+    .then((data) => callback(null, data))
+    .catch((err) => {
         callback('Could not getStats');
     });
 };

--- a/stats.js
+++ b/stats.js
@@ -1,0 +1,38 @@
+/* jshint node: true */
+const detectProvider = require('./lib/provider');
+
+module.exports = function(qc, opts) {
+
+  opts = opts || {};
+  const provider = detectProvider(opts);
+
+  const getStats = (pc) => {
+    return new Promise((resolve, reject) => {
+      // A provider must be present for logging to be enabled
+      if (!provider) return reject('No provider detected');
+      provider.getStats(pc, null, function(err, reports) {
+        if (err) return reject(err);
+        return resolve(reports);
+      });
+    });
+  }
+
+  const getConnectionStats = (pc) => {
+    return getStats(pc).then((reports) => {
+      const candidatePair = reports.filter((r) => r.type === 'candidatePair' && r.data.writable && r.data.nominated)[0];
+      const outboundRtp = reports.filter((r) => r.type === 'outboundRtp');
+      // Available outgoing bitrate not defined (Firefox)
+      if (candidatePair && candidatePair.data && typeof candidatePair.data.availableOutgoingBitrate === 'undefined') {
+        // Add a compatibility stat in (not quite the same, as this is purely based off the data that is being sent, as opposed to
+        // the potential, so named differently but possibly should just be the availableOutgoingBitrate for compatibility)
+        candidatePair.data.rtcOutgoingBitrateMean = outboundRtp.reduce((result, report) => {
+          return result + report.data.bitrateMean;
+        }, 0);
+      }
+
+      return candidatePair;
+    });
+  }
+
+  return { provider, getStats, getConnectionStats };
+};


### PR DESCRIPTION
As above, moves stats collection from index.js to stat.js, so that the stat reporting can be used without requiring a health monitor, or quickconnect instance.

As it introduces ES6 elements where there were none, this will probably be deployed as a major version increase despite the minor nature of the changes.