### PR TITLE
Update rtcOutgoingBitrateMean to handle audio channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+services:
+  - xvfb
 language: node_js
 node_js:
 - "6"
@@ -22,8 +24,6 @@ matrix:
 
 before_script:
   - ./node_modules/travis-multirunner/setup.sh
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 after_failure:
   - for file in *.log; do echo $file; echo "======================"; cat $file; done || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 language: node_js
 node_js:
 - "6"
-- "lts/*"
+# - "lts/*"
 
 env:
   matrix:

--- a/stats.js
+++ b/stats.js
@@ -26,7 +26,7 @@ module.exports = function(qc, opts) {
         // Add a compatibility stat in (not quite the same, as this is purely based off the data that is being sent, as opposed to
         // the potential, so named differently but possibly should just be the availableOutgoingBitrate for compatibility)
         candidatePair.data.rtcOutgoingBitrateMean = outboundRtp.reduce((result, report) => {
-          return result + report.data.bitrateMean;
+          return result + (report.data.bitrateMean || 0);
         }, 0);
       }
 


### PR DESCRIPTION
As a fallback mechanism for calculating available mean bitrate on Firefox, we use the `bitrateMean` value from the `outbound-rtp` stats reports.

However, only the video channel reports this metrics, so when calculating the cumulative outbound bitrate of all channels, if the channel doesn't report this metric (ie. audio) then simply add 0.